### PR TITLE
Improved column separator detection by ignoring quoted sections

### DIFF
--- a/lib/smarter_csv/auto_detection.rb
+++ b/lib/smarter_csv/auto_detection.rb
@@ -19,7 +19,10 @@ module SmarterCSV
       count.times do
         line = readline_with_counts(filehandle, options)
         delimiters.each do |d|
-          candidates[d] += line.scan(d).count
+          # Count only non-quoted occurrences of the delimiter
+          non_quoted_text = line.split(/"[^"]*"|'[^']*'/).join
+
+          candidates[d] += non_quoted_text.scan(d).count
         end
       rescue EOFError # short files
         break

--- a/lib/smarter_csv/auto_detection.rb
+++ b/lib/smarter_csv/auto_detection.rb
@@ -19,8 +19,10 @@ module SmarterCSV
       count.times do
         line = readline_with_counts(filehandle, options)
         delimiters.each do |d|
+          escaped_quote = Regexp.escape(options[:quote_char])
+
           # Count only non-quoted occurrences of the delimiter
-          non_quoted_text = line.split(/"[^"]*"|'[^']*'/).join
+          non_quoted_text = line.split(/#{escaped_quote}[^#{escaped_quote}]*#{escaped_quote}/).join
 
           candidates[d] += non_quoted_text.scan(d).count
         end

--- a/spec/features/formating/column_separator_spec.rb
+++ b/spec/features/formating/column_separator_spec.rb
@@ -87,6 +87,14 @@ describe 'can handle col_sep' do
         end.to raise_exception SmarterCSV::NoColSepDetected
       end
 
+      it 'does not detect separators that are between quotes' do
+        data = SmarterCSV.process("#{fixture_path}/separator_chars_between_quotes.csv", options)
+
+
+        expect(data.first.keys.size).to eq 5
+        expect(data.size).to eq 3
+      end
+
       context 'when auto is given as a string' do
         let(:options) do
           {
@@ -146,6 +154,14 @@ describe 'can handle col_sep' do
         expect do
           SmarterCSV.process("#{fixture_path}/binary_no_headers.csv", options)
         end.to raise_exception SmarterCSV::NoColSepDetected
+      end
+
+      it 'does not detect separators that are between quotes' do
+        data = SmarterCSV.process("#{fixture_path}/separator_chars_between_quotes_no_headers.csv", options)
+
+
+        expect(data.first.keys.size).to eq 4
+        expect(data.size).to eq 3
       end
 
       context 'when auto is given as a string' do

--- a/spec/features/formating/column_separator_spec.rb
+++ b/spec/features/formating/column_separator_spec.rb
@@ -157,10 +157,12 @@ describe 'can handle col_sep' do
       end
 
       it 'does not detect separators that are between quotes' do
-        data = SmarterCSV.process("#{fixture_path}/separator_chars_between_quotes_no_headers.csv", options)
+        data = SmarterCSV.process(
+          "#{fixture_path}/separator_chars_between_quotes_no_headers.csv",
+          options.merge(user_provided_headers: %w[Name Age Job Department Project])
+        )
 
-
-        expect(data.first.keys.size).to eq 4
+        expect(data.first.keys.size).to eq 5
         expect(data.size).to eq 3
       end
 

--- a/spec/fixtures/separator_chars_between_quotes.csv
+++ b/spec/fixtures/separator_chars_between_quotes.csv
@@ -1,0 +1,4 @@
+"name; info":"age, years":"job; title":"department":"project; code"
+"John, Doe":"35":"Senior; Developer":"Engineering":"Code:1234"
+"Jane; Smith":"29":"Project, Manager":"Product; Development":"Code,5678"
+"Emily\tJones":"42":"CTO":"Technology\t":"Code\t9012"

--- a/spec/fixtures/separator_chars_between_quotes.csv
+++ b/spec/fixtures/separator_chars_between_quotes.csv
@@ -1,4 +1,4 @@
-"name; info":"age, years":"job; title":"department":"project; code"
-"John, Doe":"35":"Senior; Developer":"Engineering":"Code:1234"
-"Jane; Smith":"29":"Project, Manager":"Product; Development":"Code,5678"
-"Emily\tJones":"42":"CTO":"Technology\t":"Code\t9012"
+"name, info":"age, years":"job, title":"department, info":"project, code"
+"John, Doe":"35, years":"Senior, Developer":"Engineering, Dept":"Code, 1234"
+"Jane, Smith":"29, years":"Project, Manager":"Product, Development":"Code,5678"
+"Emily, Jones":"42, years":"CTO,":"Technology,Dept":"Code,9012"

--- a/spec/fixtures/separator_chars_between_quotes_no_headers.csv
+++ b/spec/fixtures/separator_chars_between_quotes_no_headers.csv
@@ -1,3 +1,3 @@
-"John, Doe":"35":"Senior; Developer":"Engineering":"Code:1234"
-"Jane; Smith":"29":"Project, Manager":"Product; Development":"Code,5678"
-"Emily\tJones":"42":"CTO":"Technology\t":"Code\t9012"
+"John, Doe":"35, years":"Senior, Developer":"Engineering, Dept":"Code, 1234"
+"Jane, Smith":"29, years":"Project, Manager":"Product, Development":"Code,5678"
+"Emily, Jones":"42, years":"CTO,":"Technology,Dept":"Code,9012"

--- a/spec/fixtures/separator_chars_between_quotes_no_headers.csv
+++ b/spec/fixtures/separator_chars_between_quotes_no_headers.csv
@@ -1,0 +1,3 @@
+"John, Doe":"35":"Senior; Developer":"Engineering":"Code:1234"
+"Jane; Smith":"29":"Project, Manager":"Product; Development":"Code,5678"
+"Emily\tJones":"42":"CTO":"Technology\t":"Code\t9012"


### PR DESCRIPTION
## Summary:

This pull request enhances the logic used to determine the column separator (delimiter) in CSV files processed by our system. Previously, the method guess_column_separator simply counted occurrences of potential delimiters (such as commas, tabs, semicolons, colons, and pipes) without considering their context. This could lead to misidentification, especially when non-delimiter characters within quoted fields were mistaken for actual delimiters. The updated logic now intelligently ignores delimiters found within quoted sections, leading to more accurate delimiter detection.

## Changes:

- [x] Modified the guess_column_separator method to exclude text within quotes when counting delimiter occurrences.
- [x] Added regex-based splitting to remove quoted sections before counting delimiter occurrences in each line.



